### PR TITLE
[Feature] Facet anaylsis

### DIFF
--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -1,8 +1,9 @@
-import '../globals.css'
 import { ThemeProvider } from '@/components/ThemeProvider'
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
-import { Search } from './search/Search'
+import '../globals.css'
+import { DarkModeController } from './DarkModeController'
 import { Nav } from './Nav'
+import { Search } from './search/Search'
 
 const defaultQueryClient = () =>
   new QueryClient({
@@ -16,12 +17,14 @@ const defaultQueryClient = () =>
 export function App({ queryClient = defaultQueryClient() }: { queryClient?: QueryClient }) {
   return (
     <ThemeProvider defaultTheme="system" storageKey="vite-ui-theme">
-      <QueryClientProvider client={queryClient}>
-        <div className="bg-background">
-          <Nav />
-          <Search />
-        </div>
-      </QueryClientProvider>
+      <DarkModeController>
+        <QueryClientProvider client={queryClient}>
+          <div className="bg-background">
+            <Nav />
+            <Search />
+          </div>
+        </QueryClientProvider>
+      </DarkModeController>
     </ThemeProvider>
   )
 }

--- a/src/components/DarkModeController.tsx
+++ b/src/components/DarkModeController.tsx
@@ -1,0 +1,47 @@
+import { FC, PropsWithChildren, createContext, useContext, useEffect, useState } from "react";
+import { useTheme } from "./ThemeProvider";
+
+interface Context {
+  backgroundColor: string;
+  isDark: boolean;
+  setIsDark: (dark: boolean) => void;
+}
+interface Props extends PropsWithChildren {}
+
+const context = createContext<Context | undefined >(undefined);
+
+export const DarkModeController: FC<Props> = ({
+  children
+}) => {
+  const { theme, systemTheme } = useTheme()
+  const [isDark, setIsDark] = useState(theme === 'dark' || (theme === 'system' && systemTheme === 'dark'));
+  const [backgroundColor, setBackgroundColor] = useState(isDark ? '#171e25' : '#1f2f40');
+
+  useEffect(() => {
+    const isCurrentDark = theme === 'dark' || (theme === 'system' && systemTheme === 'dark');
+    setIsDark(isCurrentDark)
+    setBackgroundColor(isCurrentDark ? '#171e25' : '#1f2f40');
+  }, [theme]);
+
+
+  return (
+    <context.Provider
+      value={{
+        backgroundColor,
+        isDark,
+        setIsDark,
+      }}
+    >
+      {children}
+    </context.Provider>
+  )
+}
+
+// Purposefully ignoring fast-refresh (isn't applicable here)
+// eslint-disable-next-line react-refresh/only-export-components
+export const useDarkMode = (): Context => {
+  const name = DarkModeController.name;
+  const data = useContext(context);
+  if (!data) throw new Error(`Missing ${name} in tree above ${name}`);
+  return data;
+}

--- a/src/components/FacetAnalysis.tsx
+++ b/src/components/FacetAnalysis.tsx
@@ -1,6 +1,6 @@
 import { Aggregation } from "@/models/Aggregation";
 import { FC, useEffect, useState } from "react";
-import { Bar, BarChart, ResponsiveContainer, Tooltip, XAxis, YAxis } from "recharts";
+import { Bar, BarChart, Rectangle, ResponsiveContainer, Tooltip, XAxis, YAxis } from "recharts";
 import { DarkModeController, useDarkMode } from "./DarkModeController";
 
 interface Props {
@@ -32,9 +32,6 @@ export const FacetAnalysis: FC<Props> = ({ aggregation, hint, title }) => {
             bottom: 5,
           }}
         >
-          <Bar dataKey="doc_count" fill="#0099a5" />
-          <XAxis dataKey="name" />
-          <YAxis />
           <Tooltip
             content={({ payload, label }) => (
               <div className="recharts-custom-tooltip p-2" style={{ backgroundColor }}>
@@ -52,6 +49,9 @@ export const FacetAnalysis: FC<Props> = ({ aggregation, hint, title }) => {
               </div>
             )}
           />
+          <Bar dataKey="doc_count" fill="#0099a5" activeBar={<Rectangle fill="#0099a5" stroke={backgroundColor} />} />
+          <XAxis dataKey="name" />
+          <YAxis />
         </BarChart>
       </ResponsiveContainer>
       {hint && <h3 className={'text-xl text-center'}>{hint}</h3>}

--- a/src/components/FacetAnalysis.tsx
+++ b/src/components/FacetAnalysis.tsx
@@ -1,4 +1,5 @@
 import { Aggregation } from "@/models/Aggregation";
+import { theme } from "@/theme";
 import { FC, useEffect, useState } from "react";
 import { Bar, BarChart, Rectangle, ResponsiveContainer, Tooltip, XAxis, YAxis } from "recharts";
 import { DarkModeController, useDarkMode } from "./DarkModeController";
@@ -54,7 +55,7 @@ export const FacetAnalysis: FC<Props> = ({ aggregation, hint, title }) => {
               </div>
             )}
           />
-          <Bar dataKey="doc_count" fill="#0099a5" activeBar={<Rectangle fill="#0099a5" stroke={backgroundColor} />} />
+          <Bar dataKey="doc_count" fill={theme.brand} activeBar={<Rectangle fill={theme.brand} stroke={backgroundColor} />} />
           <XAxis dataKey="name" />
           <YAxis />
         </BarChart>

--- a/src/components/FacetAnalysis.tsx
+++ b/src/components/FacetAnalysis.tsx
@@ -19,9 +19,14 @@ export const FacetAnalysis: FC<Props> = ({ aggregation, hint, title }) => {
 
   return (
     <div>
-      {title && <h1 className={'text-2xl'}>{title}</h1>}
-      <ResponsiveContainer className={"my-6"} width={resetContainer} height={resetContainer}>
+      {title && <h1 aria-label="bar-chart-title" className={'text-2xl'}>{title}</h1>}
+      <ResponsiveContainer
+        className={"my-6"}
+        width={resetContainer}
+        height={resetContainer}
+      >
         <BarChart
+          aria-label="bar-chart"
           width={600}
           height={600}
           data={data}
@@ -54,7 +59,7 @@ export const FacetAnalysis: FC<Props> = ({ aggregation, hint, title }) => {
           <YAxis />
         </BarChart>
       </ResponsiveContainer>
-      {hint && <h3 className={'text-xl text-center'}>{hint}</h3>}
+      {hint && <h3 aria-label="bar-chart-hint" className={'text-xl text-center'}>{hint}</h3>}
     </div>
   )
 }

--- a/src/components/FacetAnalysis.tsx
+++ b/src/components/FacetAnalysis.tsx
@@ -1,0 +1,59 @@
+import { Aggregation } from "@/models/Aggregation";
+import { FC, useEffect, useState } from "react";
+import { Bar, BarChart, ResponsiveContainer, Tooltip, XAxis, YAxis } from "recharts";
+
+interface Props {
+  aggregation: Aggregation;
+  hint?: string;
+  title?: string;
+}
+
+export const FacetAnalysis: FC<Props> = ({ aggregation, hint, title }) => {
+  const data = aggregation.buckets.map(({ key, doc_count }) => ({ name: new Date(key).getFullYear(), doc_count }))
+  const [resetContainer, setResetContainer] = useState<number | string>(800);
+  
+  // Work around first render bug with recharts
+  // https://github.com/recharts/recharts/issues/2268
+  useEffect(() => setResetContainer('100%'), []);
+
+  return (
+    <div>
+      {title && <h1 className={'text-2xl'}>{title}</h1>}
+      <ResponsiveContainer className={"my-6"} width={resetContainer} height={resetContainer}>
+        <BarChart
+          width={600}
+          height={600}
+          data={data}
+          margin={{
+            top: 5,
+            right: 30,
+            left: 20,
+            bottom: 5,
+          }}
+        >
+          <Bar dataKey="doc_count" fill="#0099a5" />
+          <XAxis dataKey="name" />
+          <YAxis />
+          <Tooltip
+            content={({ payload, label }) => (
+              <div className="recharts-custom-tooltip bg-current p-2">
+                <p className="tooltip-label text-black font-bold">{label}</p>
+                {payload?.length &&
+                  payload.map(({ name, color, value }, index) => {
+                    const textColor = color ?? '#000';
+                    return (
+                      <p key={index} className="tooltip-items text-black">
+                        {`${name === 'doc_count' ? 'Document Count' : name}: `}
+                        <span className={'font-semibold'} style={{ color: textColor }}>{`${value}`}</span>
+                      </p>
+                    );
+                  })}
+              </div>
+            )}
+          />
+        </BarChart>
+      </ResponsiveContainer>
+      {hint && <h3 className={'text-xl text-center'}>{hint}</h3>}
+    </div>
+  )
+}

--- a/src/components/FacetAnalysis.tsx
+++ b/src/components/FacetAnalysis.tsx
@@ -1,6 +1,7 @@
 import { Aggregation } from "@/models/Aggregation";
 import { FC, useEffect, useState } from "react";
 import { Bar, BarChart, ResponsiveContainer, Tooltip, XAxis, YAxis } from "recharts";
+import { DarkModeController, useDarkMode } from "./DarkModeController";
 
 interface Props {
   aggregation: Aggregation;
@@ -11,7 +12,7 @@ interface Props {
 export const FacetAnalysis: FC<Props> = ({ aggregation, hint, title }) => {
   const data = aggregation.buckets.map(({ key, doc_count }) => ({ name: new Date(key).getFullYear(), doc_count }))
   const [resetContainer, setResetContainer] = useState<number | string>(800);
-  
+  const { backgroundColor } = useDarkMode();
   // Work around first render bug with recharts
   // https://github.com/recharts/recharts/issues/2268
   useEffect(() => setResetContainer('100%'), []);
@@ -36,15 +37,15 @@ export const FacetAnalysis: FC<Props> = ({ aggregation, hint, title }) => {
           <YAxis />
           <Tooltip
             content={({ payload, label }) => (
-              <div className="recharts-custom-tooltip bg-current p-2">
-                <p className="tooltip-label text-black font-bold">{label}</p>
+              <div className="recharts-custom-tooltip p-2" style={{ backgroundColor }}>
+                <p className="tooltip-label font-bold text-white">{label}</p>
                 {payload?.length &&
                   payload.map(({ name, color, value }, index) => {
-                    const textColor = color ?? '#000';
+                    const hintColor = color ?? '#fff';
                     return (
-                      <p key={index} className="tooltip-items text-black">
+                      <p key={index} className="tooltip-items text-white">
                         {`${name === 'doc_count' ? 'Document Count' : name}: `}
-                        <span className={'font-semibold'} style={{ color: textColor }}>{`${value}`}</span>
+                        <span className={'font-semibold'} style={{ color: hintColor }}>{`${value}`}</span>
                       </p>
                     );
                   })}
@@ -57,3 +58,9 @@ export const FacetAnalysis: FC<Props> = ({ aggregation, hint, title }) => {
     </div>
   )
 }
+
+export const SBFacetAnalysis: FC<Props> = (props) => (
+  <DarkModeController>
+    <FacetAnalysis {...props} />
+  </DarkModeController>
+)

--- a/src/components/Nav.tsx
+++ b/src/components/Nav.tsx
@@ -1,13 +1,12 @@
-import { Link, useQueryParams } from 'raviger'
-import { useTheme } from '@/components/ThemeProvider'
-import { theme as colors } from '@/theme'
-import { ModeToggle } from './DarkModeToggle'
+import { Link, useQueryParams } from 'raviger';
+import { FC } from 'react';
+import { DarkModeController, useDarkMode } from './DarkModeController';
+import { ModeToggle } from './DarkModeToggle';
+
 
 export function Nav() {
   const [{ q }] = useQueryParams()
-  const { theme, systemTheme } = useTheme()
-  const isDark = theme === 'dark' || (theme === 'system' && systemTheme === 'dark')
-  const backgroundColor = isDark ? '#171e25' : '#1f2f40' // TODO: system?
+  const { backgroundColor } = useDarkMode();
   return (
     <nav className={'text-white flex p-1'} style={{ backgroundColor }}>
       <Link className={'p-4 py-2'} href={'/'}>
@@ -27,3 +26,10 @@ export function Nav() {
     </nav>
   )
 }
+
+
+export const StoryBookNav: FC = () => (
+  <DarkModeController>
+    <Nav />
+  </DarkModeController>
+)

--- a/src/stories/FacetAnalysis.stories.tsx
+++ b/src/stories/FacetAnalysis.stories.tsx
@@ -1,8 +1,12 @@
 import { SBFacetAnalysis as Component } from '@/components/FacetAnalysis'
 import { Meta, StoryObj } from '@storybook/react'
+import { expect, within } from '@storybook/test'
 import AGGREGATIONS from '../fixtures/patent-facets.json'
 
 type Story = StoryObj<typeof Component>
+
+const title = "Publications over time";
+const hint = "Highlight a selection to filter by date";
 
 const meta: Meta<typeof Component> = {
   title: 'Components/FacetAnalysis',
@@ -10,11 +14,32 @@ const meta: Meta<typeof Component> = {
   decorators: [],
   args: {
     aggregation: AGGREGATIONS.aggregations.dates,
-    title: "Publications over time",
-    hint: "Highlight a selection to filter by date"
+    title,
+    hint,
   }
 }
 
 export default meta
 
-export const FacetAnalysis: Story = {}
+export const FacetAnalysis: Story = {
+  play: async ({ canvasElement, step }) => {
+    const canvas = within(canvasElement);
+
+    await step('Check to see if Title is displayed', async () => {
+      const data = await canvas.findByLabelText('bar-chart-title')
+      expect(data).not.toBeNull();
+      expect(data).toBeDefined()
+    });
+
+    await step('Check to see if Hint is displayed', async () => {
+      const data = await canvas.findByLabelText('bar-chart-hint')
+      expect(data).not.toBeNull();
+      expect(data).toBeDefined()
+    })
+
+    await step('Check to bar chart exists', async () => {
+      const barChart = await canvas.findByLabelText('bar-chart')
+      expect(barChart).toBeDefined()
+    })
+  }
+}

--- a/src/stories/FacetAnalysis.stories.tsx
+++ b/src/stories/FacetAnalysis.stories.tsx
@@ -1,6 +1,5 @@
-import { FacetAnalysis as Component } from '@/components/FacetAnalysis'
+import { SBFacetAnalysis as Component } from '@/components/FacetAnalysis'
 import { Meta, StoryObj } from '@storybook/react'
-
 import AGGREGATIONS from '../fixtures/patent-facets.json'
 
 type Story = StoryObj<typeof Component>

--- a/src/stories/FacetAnalysis.stories.tsx
+++ b/src/stories/FacetAnalysis.stories.tsx
@@ -1,0 +1,21 @@
+import { FacetAnalysis as Component } from '@/components/FacetAnalysis'
+import { Meta, StoryObj } from '@storybook/react'
+
+import AGGREGATIONS from '../fixtures/patent-facets.json'
+
+type Story = StoryObj<typeof Component>
+
+const meta: Meta<typeof Component> = {
+  title: 'Components/FacetAnalysis',
+  component: Component,
+  decorators: [],
+  args: {
+    aggregation: AGGREGATIONS.aggregations.dates,
+    title: "Publications over time",
+    hint: "Highlight a selection to filter by date"
+  }
+}
+
+export default meta
+
+export const FacetAnalysis: Story = {}

--- a/src/stories/Nav.stories.tsx
+++ b/src/stories/Nav.stories.tsx
@@ -1,4 +1,4 @@
-import { Nav as Component } from '@/components/Nav'
+import { StoryBookNav as Component } from '@/components/Nav'
 import { Meta, StoryObj } from '@storybook/react'
 
 type Story = StoryObj<typeof Component>


### PR DESCRIPTION
The goal of this feature is to visualize the document count per facet by the dates. Creating the chart with data was easy enough but we'll need to re-raise a bug report with rechart as [this bug](https://github.com/recharts/recharts/issues/2268) has re-appeared on initial render.

This ticket adds a dark/light mode context with a background color for the tooltip background. This may prove useful for other components that require dark/light mode styling.

Modified stories that are using dark mode to have the necessary provider. Should create a story wrapper in the future.

> Might be good once patent preview is merged to change how `doc_count` is been transformed to use translations or merge into this branch

### Light Mode
![image](https://github.com/pepscrub/frontend-coding-test/assets/35904816/428a0980-ce16-47ed-ae48-77f6e6de0383)
### Dark Mode
![image](https://github.com/pepscrub/frontend-coding-test/assets/35904816/32a3c811-a625-4833-b438-68e4da5891c4)
